### PR TITLE
fix helm repo addr

### DIFF
--- a/install_canvas.sh
+++ b/install_canvas.sh
@@ -6,9 +6,9 @@ echo "Configuring Helm repositories"
 echo "*********************************************************************"
 echo ""
 
-helm repo add stable https://kubernetes-charts.storage.googleapis.com
+helm repo add stable https://charts.helm.sh/stable
 helm repo add codecentric https://codecentric.github.io/helm-charts
-helm repo add incubator https://kubernetes-charts-incubator.storage.googleapis.com
+helm repo add incubator https://charts.helm.sh/incubator
 
 echo ""
 echo "*********************************************************************"


### PR DESCRIPTION
Fix #14 

move https://kubernetes-charts.storage.googleapis.com to  https://charts.helm.sh/stable
move https://kubernetes-charts-incubator.storage.googleapis.com to https://charts.helm.sh/incubator
