### PR TITLE
Update Chart.yaml

### DIFF
--- a/canvas/charts/keycloak/Chart.yaml
+++ b/canvas/charts/keycloak/Chart.yaml
@@ -26,6 +26,6 @@ appVersion: "12.0.3"
 # Postgres is a dependency
 dependencies:
   - name: "postgresql"
-    version: "~10.8.0"
+    version: "^10.8.0"
     repository: "https://charts.bitnami.com/bitnami"
     condition: "postgresql.enabled"


### PR DESCRIPTION
Hi Postgres 10.8.0 is not part of Bitnami chart anymore, we will need to update.

I'm using the wildcard operator, but we may want to fix on a specific version, there are a couple of people waiting for this fix.

close #39
