### PR TITLE
Update component custom resource definition to v1beta1

### DIFF
--- a/Installation.md
+++ b/Installation.md
@@ -37,3 +37,13 @@ Finally, you will also need to configure Keycloak as follows:
 ### Notes
 - It is possible to enable or disable creation of namespaces in the ```values.yaml``` file.
 - Names of namespaces are set to ```canvas``` and ```components``` unless overridden.
+
+## Step 5 (only if using Istio Service Mesh)
+
+If you are deploying on Istio Service Mesh, you have to enable Istio injection in the namespaces where the canvas and components will be deployed. This can be done by running the following commands:
+
+
+```bash
+kubectl label namespace canvas istio-injection=enabled
+kubectl label namespace components istio-injection=enabled
+```

--- a/canvas/charts/controller/templates/rbac.yaml
+++ b/canvas/charts/controller/templates/rbac.yaml
@@ -42,7 +42,7 @@ rules:
     resources: [apis]
     verbs: [list, watch, patch, get, create, update, delete]
   - apiGroups: [""] # "" indicates the core API group
-    resources: ["services", "services/status", "pods", "persistentvolumeclaims", "persistentvolumeclaims/status", "namespaces", "configmaps", "configmaps/status", "secret", "secret/status", "serviceaccounts", "serviceaccounts/status"]
+    resources: ["services", "services/status", "pods", "persistentvolumeclaims", "persistentvolumeclaims/status", "namespaces", "configmaps", "configmaps/status", "secrets", "secrets/status", "serviceaccounts", "serviceaccounts/status"]
     verbs: [list, watch, patch, get, create, update, delete]
   - apiGroups: ["networking.k8s.io"]
     resources: ["ingresses", "ingresses/status"]

--- a/canvas/charts/controller/templates/rbac.yaml
+++ b/canvas/charts/controller/templates/rbac.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     {{- include "controller.labels" . | nindent 4 }}
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: odacomponent-role-cluster
@@ -80,7 +80,7 @@ rules:
     verbs: [list, watch, patch, get, create, update, delete]
 
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   namespace: {{.Values.global.namespaceDefault.name}}
@@ -141,7 +141,7 @@ rules:
 #    verbs: [create, watch, list]
 
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: odacomponent-rolebinding-cluster
@@ -156,7 +156,7 @@ subjects:
     name: odacomponent-account
     namespace: {{ .Release.Namespace }}
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   namespace: {{.Values.global.namespaceDefault.name}}

--- a/canvas/charts/controller/values.yaml
+++ b/canvas/charts/controller/values.yaml
@@ -1,5 +1,5 @@
 deployment:
-  compconimage: tmforumodacanvas/component-istio-controller:0.2.3
+  compconimage: tmforumodacanvas/component-istio-controller:0.2.6
   istioGateway: true
   secconimage: tmforumodacanvas/security-listener:0.6.0
   monitorednamespaces: 'components'           # comma separated list of namespaces

--- a/canvas/charts/controller/values.yaml
+++ b/canvas/charts/controller/values.yaml
@@ -1,5 +1,5 @@
 deployment:
-  compconimage: tmforumodacanvas/component-istio-controller:0.1.5
+  compconimage: tmforumodacanvas/component-istio-controller:0.2.3
   istioGateway: true
   secconimage: tmforumodacanvas/security-listener:0.6.0
   monitorednamespaces: 'components'           # comma separated list of namespaces

--- a/canvas/charts/crds/templates/oda-api-crd.yaml
+++ b/canvas/charts/crds/templates/oda-api-crd.yaml
@@ -111,4 +111,30 @@ spec:
     - name: Implementation_ready
       type: string
       description: API implementation is ready - has passed startup probe checks
-      jsonPath: .status.implementation.ready      
+      jsonPath: .status.implementation.ready
+  - name: "v1beta1"
+    # Each version can be enabled/disabled by Served flag.
+    served: true
+    # One and only one version must be marked as the storage version.
+    storage: false
+    deprecated: false
+    schema:
+      openAPIV3Schema:
+        type: object
+        required: ["spec"]
+        properties:
+          spec:
+            type: object                
+            x-kubernetes-preserve-unknown-fields: true    
+          status:
+            type: object
+            x-kubernetes-preserve-unknown-fields: true    
+    additionalPrinterColumns:
+    - name: API_endpoint
+      type: string
+      description: API endpoint Url
+      jsonPath: .status.apiStatus.url    
+    - name: Implementation_ready
+      type: string
+      description: API implementation is ready - has passed startup probe checks
+      jsonPath: .status.implementation.ready            

--- a/canvas/charts/crds/templates/oda-component-crd.yaml
+++ b/canvas/charts/crds/templates/oda-component-crd.yaml
@@ -659,8 +659,9 @@ spec:
                           description: url to the specification of the API, if required. e.g. url to the swagger file for Open API.
                         apitype:
                           type: string
-                          enum: [openapi, prometheus]
-                          description: The type of API specification. Currently only OpenAPI (swagger) and Prometheus (metrics) APIs are supported.
+                          enum:
+                          - openapi
+                        description: The type of API specification. Currently only OpenAPI (swagger) and Prometheus (metrics) APIs are supported.
                         implementation:
                           type: string
                           description: The name of the service where the implementation of the API is found
@@ -686,7 +687,6 @@ spec:
                       properties:
                         name:
                           type: string
-                          required: true
                           description: Name of the API that this component is dependent on
                         specification:
                           type: string
@@ -694,9 +694,12 @@ spec:
                           description: url to the specification of the API. e.g. url to the swagger file
                         apitype:
                           type: string
-                          required: true
-                          enum: [openapi, prometheus]
-                          description: The type of API specification. Currently only OpenAPI (swagger) and Prometheus (metrics) APIs are supported.
+                          enum:
+                          - openapi
+                        description: The type of API specification. Currently only OpenAPI (swagger) and Prometheus (metrics) APIs are supported.
+                      required:
+                      - name
+                      - apitype
               eventNotification:
                 type: object  
                 properties:  
@@ -728,7 +731,6 @@ spec:
                       properties:
                         name:
                           type: string
-                          required: true
                           description: Name of the API
                         specification:
                           type: string
@@ -736,23 +738,21 @@ spec:
                           description: url to the specification of the API. e.g. url to the swagger file
                         apitype:
                           type: string
-                          required: true
-                          enum: [openapi, prometheus]
-                          description: The type of API specification. Currently only OpenAPI (swagger) and Prometheus (metrics) APIs are supported.
+                          enum:
+                          - openapi
+                          - prometheus
+                        description: The type of API specification. Currently only OpenAPI (swagger) and Prometheus (metrics) APIs are supported.
                         implementation:
                           type: string
-                          required: true
                           description: The name of the service where the implementation of the API is found
                         path:
                           type: string
-                          required: true
                           description: The path to the root of the API
                         developerUI:
                           type: string
                           description: (optional) The path to the developer User Interface for the API
                         port:
                           type: integer
-                          required: true
                           description: The port where the API is exposed 
                       required:
                       - name
@@ -767,7 +767,6 @@ spec:
                       properties:
                         name:
                           type: string
-                          required: true
                           description: Name of the API that this component is dependent on
                         specification:
                           type: string
@@ -775,9 +774,13 @@ spec:
                           description: url to the specification of the API. e.g. url to the swagger file
                         apitype:
                           type: string
-                          required: true
-                          enum: [openapi, prometheus]
-                          description: The type of API specification. Currently only OpenAPI (swagger) and Prometheus APIs are supported.
+                          enum:
+                          - openapi
+                          - prometheus
+                        description: The type of API specification. Currently only OpenAPI (swagger) and Prometheus APIs are supported.
+                      required:
+                      - name
+                      - apitype
               security:
                 type: object  
                 properties:  
@@ -788,7 +791,6 @@ spec:
                       properties:
                         name:
                           type: string
-                          required: true
                           description: Name of the API
                         specification:
                           type: string
@@ -796,23 +798,20 @@ spec:
                           description: url to the specification of the API. e.g. url to the swagger file
                         apitype:
                           type: string
-                          required: true
-                          enum: [openapi, prometheus]
-                          description: The type of API specification. Currently only OpenAPI (swagger) and Prometheus APIs are supported.
+                          enum:
+                          - openapi
+                        description: The type of API specification. Currently only OpenAPI (swagger) and Prometheus APIs are supported.
                         implementation:
                           type: string
-                          required: true
                           description: The name of the service where the implementation of the API is found
                         path:
                           type: string
-                          required: true
                           description: The path to the root of the API
                         developerUI:
                           type: string
                           description: (optional) The path to the developer User Interface for the API
                         port:
                           type: integer
-                          required: true
                           description: The port where the API is exposed 
                       required:
                       - name
@@ -827,7 +826,6 @@ spec:
                       properties:
                         name:
                           type: string
-                          required: true
                           description: Name of the API that this component is dependent on
                         specification:
                           type: string
@@ -835,9 +833,12 @@ spec:
                           description: url to the specification of the API. e.g. url to the swagger file
                         apitype:
                           type: string
-                          required: true
-                          enum: [openapi, prometheus]
-                          description: The type of API specification. Currently only OpenAPI (swagger) and Prometheus APIs are supported.
+                          enum:
+                          - openapi
+                        description: The type of API specification. Currently only OpenAPI (swagger) and Prometheus APIs are supported.
+                      required:
+                      - name
+                      - apitype
                   controllerRole:
                     description: This is the name of the role that the Canvas controllers will use to interact with the component's APIs.
                       It must exist in the roles exposed by the partyRole API.

--- a/canvas/charts/crds/templates/oda-component-crd.yaml
+++ b/canvas/charts/crds/templates/oda-component-crd.yaml
@@ -624,14 +624,11 @@ spec:
                       description: Name is the descriptive name.
                       type: string
                     url:
-                      description: Url could typically be a website address.
+                      description: Website address of maintaining organization.
                       type: string
               owners:
                 type: array
-                description: Owners is an optional list of the owners of the installed
-                  component. The owners of the component should be contacted
-                  in the event of a planned or unplanned disruption affecting
-                  the component.
+                description: Owners is an optional list of the owners of the installed component. 
                 items:
                   type: object
                   description: ContactData contains information about an individual or organization.
@@ -643,7 +640,7 @@ spec:
                       description: Name is the descriptive name.
                       type: string
                     url:
-                      description: Url could typically be a website address.
+                      description: Website address of owning organization.
                       type: string                 
               coreFunction:
                 type: object  
@@ -659,11 +656,11 @@ spec:
                         specification:
                           type: string
                           format: url
-                          description: url to the specification of the API. e.g. url to the swagger file
+                          description: url to the specification of the API, if required. e.g. url to the swagger file for Open API.
                         apitype:
                           type: string
                           enum: [openapi, prometheus]
-                          description: The type of API specification. Currently only OpenAPI (swagger) and Prometheus APIs are supported.
+                          description: The type of API specification. Currently only OpenAPI (swagger) and Prometheus (metrics) APIs are supported.
                         implementation:
                           type: string
                           description: The name of the service where the implementation of the API is found
@@ -676,6 +673,12 @@ spec:
                         port:
                           type: integer
                           description: The port where the API is exposed 
+                      required:
+                      - name
+                      - apitype
+                      - implementation
+                      - path
+                      - port
                   dependentAPIs:   
                     type: array
                     items:
@@ -693,7 +696,7 @@ spec:
                           type: string
                           required: true
                           enum: [openapi, prometheus]
-                          description: The type of API specification. Currently only OpenAPI (swagger) and Prometheus APIs are supported.
+                          description: The type of API specification. Currently only OpenAPI (swagger) and Prometheus (metrics) APIs are supported.
               eventNotification:
                 type: object  
                 properties:  
@@ -735,7 +738,7 @@ spec:
                           type: string
                           required: true
                           enum: [openapi, prometheus]
-                          description: The type of API specification. Currently only OpenAPI (swagger) and Prometheus APIs are supported.
+                          description: The type of API specification. Currently only OpenAPI (swagger) and Prometheus (metrics) APIs are supported.
                         implementation:
                           type: string
                           required: true
@@ -751,6 +754,12 @@ spec:
                           type: integer
                           required: true
                           description: The port where the API is exposed 
+                      required:
+                      - name
+                      - apitype
+                      - implementation
+                      - path
+                      - port
                   dependentAPIs:   
                     type: array
                     items:
@@ -805,6 +814,12 @@ spec:
                           type: integer
                           required: true
                           description: The port where the API is exposed 
+                      required:
+                      - name
+                      - apitype
+                      - implementation
+                      - path
+                      - port
                   dependentAPIs:   
                     type: array
                     items:

--- a/canvas/charts/crds/templates/oda-component-crd.yaml
+++ b/canvas/charts/crds/templates/oda-component-crd.yaml
@@ -24,11 +24,11 @@ spec:
   versions: 
   - name: "v1alpha1"
     # Each version can be enabled/disabled by Served flag.
-    served: true
+    served: false
     # One and only one version must be marked as the storage version.
     storage: false
     deprecated: true
-    deprecationWarning: "oda.tmforum.org/v1alpha1 Component is deprecated; Please upgrade to oda.tmforum.org/v1alpha3 see https://github.com/tmforum-oda/oda-canvas-charts/issues/19"
+    deprecationWarning: "oda.tmforum.org/v1alpha1 Component is deprecated; Please upgrade to oda.tmforum.org/v1beta1 see https://github.com/tmforum-oda/oda-canvas-charts/issues/19"
     schema:
       openAPIV3Schema:
         type: object
@@ -150,8 +150,8 @@ spec:
     served: true
     # One and only one version must be marked as the storage version.
     storage: false
-    # deprecated: false
-    # deprecationWarning: "oda.tmforum.org/v1alpha1 Component is deprecated; Please upgrade to oda.tmforum.org/v1alpha2 see https://github.com/tmforum-oda/oda-canvas-charts/issues/9"
+    deprecated: true
+    deprecationWarning: "oda.tmforum.org/v1alpha2 Component is deprecated; Please upgrade to oda.tmforum.org/v1beta1"
     schema:
       openAPIV3Schema:
         type: object
@@ -424,8 +424,6 @@ spec:
     served: true
     # One and only one version must be marked as the storage version.
     storage: true
-    # deprecated: false
-    # deprecationWarning: "oda.tmforum.org/v1alpha1 Component is deprecated; Please upgrade to oda.tmforum.org/v1alpha2 see https://github.com/tmforum-oda/oda-canvas-charts/issues/9"
     schema:
       openAPIV3Schema:
         type: object
@@ -584,6 +582,256 @@ spec:
       type: string
       description: list the Developer User Interface(s)
       jsonPath: .status.summary/status.developerUIsummary
+    - name: deployment_status
+      type: string
+      description: Deployment status [in progress, complete, failed]
+      jsonPath: .status.summary/status.deployment_status
+  - name: "v1beta1"
+    # Each version can be enabled/disabled by Served flag.
+    served: true
+    # One and only one version must be marked as the storage version.
+    storage: false
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          spec:
+            type: object
+            properties:
+              type:
+                type: string
+                description: This is the type of functional component and must refer to a TM Forum published type.
+                example: TMFC001-productcatalogmanagement
+              version:
+                type: string
+                description: This is the version of the component (it is specific to the vendor of this component and not the type).
+              description:
+                type: string
+                description: This is a short description of the component's purpose.
+              maintainers:
+                type: array  
+                description: Maintainers is an optional list of maintainers of
+                  the component. The maintainers in this list maintain the the
+                  source code, images, and package for the component.
+                items:
+                  description: ContactData contains information about an individual or organization.
+                  type: object
+                  properties:
+                    email:
+                      description: Email is the email address.
+                      type: string
+                    name:
+                      description: Name is the descriptive name.
+                      type: string
+                    url:
+                      description: Url could typically be a website address.
+                      type: string
+              owners:
+                type: array
+                description: Owners is an optional list of the owners of the installed
+                  component. The owners of the component should be contacted
+                  in the event of a planned or unplanned disruption affecting
+                  the component.
+                items:
+                  type: object
+                  description: ContactData contains information about an individual or organization.
+                  properties:
+                    email:
+                      description: Email is the email address.
+                      type: string
+                    name:
+                      description: Name is the descriptive name.
+                      type: string
+                    url:
+                      description: Url could typically be a website address.
+                      type: string                 
+              coreFunction:
+                type: object  
+                properties:  
+                  exposedAPIs:   
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        name:
+                          type: string
+                          description: Name of the API
+                        specification:
+                          type: string
+                          format: url
+                          description: url to the specification of the API. e.g. url to the swagger file
+                        apitype:
+                          type: string
+                          enum: [openapi, prometheus]
+                          description: The type of API specification. Currently only OpenAPI (swagger) and Prometheus APIs are supported.
+                        implementation:
+                          type: string
+                          description: The name of the service where the implementation of the API is found
+                        path:
+                          type: string
+                          description: The path to the root of the API
+                        developerUI:
+                          type: string
+                          description: (optional) The path to the developer User Interface for the API
+                        port:
+                          type: integer
+                          description: The port where the API is exposed 
+                  dependentAPIs:   
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        name:
+                          type: string
+                          required: true
+                          description: Name of the API that this component is dependent on
+                        specification:
+                          type: string
+                          format: url
+                          description: url to the specification of the API. e.g. url to the swagger file
+                        apitype:
+                          type: string
+                          required: true
+                          enum: [openapi, prometheus]
+                          description: The type of API specification. Currently only OpenAPI (swagger) and Prometheus APIs are supported.
+              eventNotification:
+                type: object  
+                properties:  
+                  publishedEvents: 
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        name:
+                          type: string
+                        href:
+                          type: string
+                  subscribedEvents: 
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        name:
+                          type: string
+                        href:
+                          type: string
+              management:
+                type: object  
+                properties:  
+                  exposedAPIs:   
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        name:
+                          type: string
+                          required: true
+                          description: Name of the API
+                        specification:
+                          type: string
+                          format: url
+                          description: url to the specification of the API. e.g. url to the swagger file
+                        apitype:
+                          type: string
+                          required: true
+                          enum: [openapi, prometheus]
+                          description: The type of API specification. Currently only OpenAPI (swagger) and Prometheus APIs are supported.
+                        implementation:
+                          type: string
+                          required: true
+                          description: The name of the service where the implementation of the API is found
+                        path:
+                          type: string
+                          required: true
+                          description: The path to the root of the API
+                        developerUI:
+                          type: string
+                          description: (optional) The path to the developer User Interface for the API
+                        port:
+                          type: integer
+                          required: true
+                          description: The port where the API is exposed 
+                  dependentAPIs:   
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        name:
+                          type: string
+                          required: true
+                          description: Name of the API that this component is dependent on
+                        specification:
+                          type: string
+                          format: url
+                          description: url to the specification of the API. e.g. url to the swagger file
+                        apitype:
+                          type: string
+                          required: true
+                          enum: [openapi, prometheus]
+                          description: The type of API specification. Currently only OpenAPI (swagger) and Prometheus APIs are supported.
+              security:
+                type: object  
+                properties:  
+                  exposedAPIs:   
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        name:
+                          type: string
+                          required: true
+                          description: Name of the API
+                        specification:
+                          type: string
+                          format: url
+                          description: url to the specification of the API. e.g. url to the swagger file
+                        apitype:
+                          type: string
+                          required: true
+                          enum: [openapi, prometheus]
+                          description: The type of API specification. Currently only OpenAPI (swagger) and Prometheus APIs are supported.
+                        implementation:
+                          type: string
+                          required: true
+                          description: The name of the service where the implementation of the API is found
+                        path:
+                          type: string
+                          required: true
+                          description: The path to the root of the API
+                        developerUI:
+                          type: string
+                          description: (optional) The path to the developer User Interface for the API
+                        port:
+                          type: integer
+                          required: true
+                          description: The port where the API is exposed 
+                  dependentAPIs:   
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        name:
+                          type: string
+                          required: true
+                          description: Name of the API that this component is dependent on
+                        specification:
+                          type: string
+                          format: url
+                          description: url to the specification of the API. e.g. url to the swagger file
+                        apitype:
+                          type: string
+                          required: true
+                          enum: [openapi, prometheus]
+                          description: The type of API specification. Currently only OpenAPI (swagger) and Prometheus APIs are supported.
+                  controllerRole:
+                    description: This is the name of the role that the Canvas controllers will use to interact with the component's APIs.
+                      It must exist in the roles exposed by the partyRole API.
+                    type: string             
+
+          status:
+            type: object
+            x-kubernetes-preserve-unknown-fields: true    
+    additionalPrinterColumns:
     - name: deployment_status
       type: string
       description: Deployment status [in progress, complete, failed]

--- a/canvas/charts/crds/templates/oda-component-crd.yaml
+++ b/canvas/charts/crds/templates/oda-component-crd.yaml
@@ -13,7 +13,7 @@ spec:
     strategy: Webhook
     # webhookClientConfig is required when strategy is `Webhook` and it configures the webhook endpoint to be called by API server.
     webhook:
-      conversionReviewVersions: ["v1alpha1", "v1alpha2", "v1alpha3", "v1beta1"]
+      conversionReviewVersions: ["v1beta1", "v1alpha4", "v1alpha3", "v1alpha2", "v1alpha1"]
       clientConfig:
         caBundle: {{ .Values.global.clusterCABundle }}
         service:
@@ -661,7 +661,7 @@ spec:
                           type: string
                           enum:
                           - openapi
-                        description: The type of API specification. Currently only OpenAPI (swagger) and Prometheus (metrics) APIs are supported.
+                          description: The type of API specification. Currently only OpenAPI (swagger) and Prometheus (metrics) APIs are supported.
                         implementation:
                           type: string
                           description: The name of the service where the implementation of the API is found
@@ -696,7 +696,7 @@ spec:
                           type: string
                           enum:
                           - openapi
-                        description: The type of API specification. Currently only OpenAPI (swagger) and Prometheus (metrics) APIs are supported.
+                          description: The type of API specification. Currently only OpenAPI (swagger) and Prometheus (metrics) APIs are supported.
                       required:
                       - name
                       - apitype
@@ -741,7 +741,7 @@ spec:
                           enum:
                           - openapi
                           - prometheus
-                        description: The type of API specification. Currently only OpenAPI (swagger) and Prometheus (metrics) APIs are supported.
+                          description: The type of API specification. Currently only OpenAPI (swagger) and Prometheus (metrics) APIs are supported.
                         implementation:
                           type: string
                           description: The name of the service where the implementation of the API is found
@@ -777,7 +777,7 @@ spec:
                           enum:
                           - openapi
                           - prometheus
-                        description: The type of API specification. Currently only OpenAPI (swagger) and Prometheus APIs are supported.
+                          description: The type of API specification. Currently only OpenAPI (swagger) and Prometheus APIs are supported.
                       required:
                       - name
                       - apitype
@@ -800,7 +800,7 @@ spec:
                           type: string
                           enum:
                           - openapi
-                        description: The type of API specification. Currently only OpenAPI (swagger) and Prometheus APIs are supported.
+                          description: The type of API specification. Currently only OpenAPI (swagger) and Prometheus APIs are supported.
                         implementation:
                           type: string
                           description: The name of the service where the implementation of the API is found
@@ -835,7 +835,7 @@ spec:
                           type: string
                           enum:
                           - openapi
-                        description: The type of API specification. Currently only OpenAPI (swagger) and Prometheus APIs are supported.
+                          description: The type of API specification. Currently only OpenAPI (swagger) and Prometheus APIs are supported.
                       required:
                       - name
                       - apitype
@@ -843,7 +843,6 @@ spec:
                     description: This is the name of the role that the Canvas controllers will use to interact with the component's APIs.
                       It must exist in the roles exposed by the partyRole API.
                     type: string             
-
           status:
             type: object
             x-kubernetes-preserve-unknown-fields: true    

--- a/canvas/charts/webhook/values.yaml
+++ b/canvas/charts/webhook/values.yaml
@@ -1,7 +1,7 @@
 
 # Declare variables to be passed into your templates.
 
-image: tmforumodacanvas/compcrdwebhook:0.3
+image: tmforumodacanvas/compcrdwebhook:0.5.1
 
   
 


### PR DESCRIPTION
closes #44 
closes #4 

This PR includes a number of changes to support the v1beta1 component specification. It has been tested locally against Kubernetes 1.25.