### PR TITLE
Add support for new enviroment variable to enable dataDog support

### DIFF
--- a/canvas-simplified-install/README_ODA.md
+++ b/canvas-simplified-install/README_ODA.md
@@ -180,7 +180,7 @@ oda-controller-ingress-d5c495bbb-crt4t      2/2     Running     0          4m43s
 Checking the logs of the failed Job
 
 ````bash
-2023-02-01 15:23:19.488  INFO 1 --- [           main] d.a.k.config.provider.KeycloakProvider   : Wait 120 seconds until http://canvas-keycloak-headless:8080/auth/ is available ...
+2023-02-01 15:23:19.488  INFO 1 --- [           main] d.a.k.config.provider.KeycloakProvider   : Wait 120 seconds until http://canvas-keycloak-headless:8083/auth/ is available ...
 2023-02-01 15:25:19.511 ERROR 1 --- [           main] d.a.k.config.KeycloakConfigRunner        : Could not connect to keycloak in 120 seconds: HTTP 403 Forbidden
 ````
 

--- a/canvas-simplified-install/canvas-oda/Chart.lock
+++ b/canvas-simplified-install/canvas-oda/Chart.lock
@@ -13,9 +13,9 @@ dependencies:
   version: 13.0.2
 - name: controller
   repository: file://../controller
-  version: 1.0.0
+  version: 1.0.1
 - name: oda-webhook
   repository: file://../oda-webhook
   version: 1.0.0
-digest: sha256:96bfd6a6fd994af9121a06f073a843b2d8a0de04970591ba1802b028c24c1b7c
-generated: "2023-02-08T09:11:00.1327964+01:00"
+digest: sha256:0b944833881f390cc8c566a7eb423bcb61916442d515fe72197b1b9b4ab8bea0
+generated: "2023-03-03T11:51:42.8288335+01:00"

--- a/canvas-simplified-install/canvas-oda/Chart.yaml
+++ b/canvas-simplified-install/canvas-oda/Chart.yaml
@@ -39,7 +39,7 @@ dependencies:
     repository: 'https://charts.bitnami.com/bitnami'
     condition: keycloak.enabled
   - name: controller
-    version: "1.0.0"
+    version: "1.0.1"
     repository: 'file://../controller'
   - name: oda-webhook
     version: "1.0.0"

--- a/canvas-simplified-install/canvas-oda/README.md
+++ b/canvas-simplified-install/canvas-oda/README.md
@@ -2,7 +2,7 @@
 
 ![Version: 1.0.0](https://img.shields.io/badge/Version-1.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0.0](https://img.shields.io/badge/AppVersion-1.0.0-informational?style=flat-square)
 
-A Helm of helms to orchestrate the ODA instalation
+A Helm of helm to orchestrate the ODA instalation
 
 ## Requirements
 
@@ -10,7 +10,7 @@ A Helm of helms to orchestrate the ODA instalation
 |------------|------|---------|
 | file://../canvas-namespaces | canvas-namespaces | 1.1.0 |
 | file://../cert-manager-init | cert-manager-init | 1.0.0 |
-| file://../controller | controller | 1.0.0 |
+| file://../controller | controller | 1.0.1 |
 | file://../oda-crds | oda-crds | 1.0.0 |
 | file://../oda-webhook | oda-webhook | 1.0.0 |
 | https://charts.bitnami.com/bitnami | keycloak | 13.0.2 |
@@ -21,47 +21,46 @@ A Helm of helms to orchestrate the ODA instalation
 |-----|------|---------|-------------|
 | canvas-namespaces.certManagerNamespace | string | `"cert-manager"` |  |
 | canvas-namespaces.componentNamespace | string | `"components"` |  |
-| canvas-namespaces.enabled | bool | `true` |   |
+| canvas-namespaces.enabled | bool | `true` |  |
 | canvas-namespaces.istio.labelEnabledComponent | bool | `true` | Add Istion instrumentation label to the components namespace |
 | cert-manager-init.cert-manager.enabled | bool | `true` |  |
 | cert-manager-init.cert-manager.installCRDs | bool | `true` |  |
-| cert-manager-init.cert-manager.leaseWaitTimeonStartup | int | `80` | Time to wait CertManager to be ready to prevent issuer creation errors |
 | cert-manager-init.cert-manager.namespace | string | `"cert-manager"` |  |
-| cert-manager-init.certificateDuration | string | `"21600h"` | Duration of the certificates generate for the webhook in hours |
-| cert-manager-init.leaseWaitTimeonStartup | int | `80` | Time to wait CertManager to be ready to prevent issuer creation errors |
+| cert-manager-init.certificateDuration | string | `"21600h"` | Duration of the certificates generate for the webhook in hours | |
 | cert-manager-init.fullnameOverride | string | `""` |  |
+| cert-manager-init.leaseWaitTimeonStartup | int | `20` | Time to wait CertManager to be ready to prevent issuer creation errors |
 | cert-manager-init.nameOverride | string | `""` |  |
 | cert-manager-init.namespace | string | `"canvas"` |  |
-| controller.configmap.kcrealm | string | `"myrealm"` | the Realm used to create the clients and roles from ODA components  |
-| controller.configmap.loglevel | string | `"20"` |  Log level (python) https://docs.python.org/3/library/logging.html |
-| controller.credentials.pass | string | `"adpass"` | Admin user in Keycloak  password  |
+| controller.configmap.kcrealm | string | `"myrealm"` |  |
+| controller.configmap.loglevel | string | `"20"` | Log level [python] (https://docs.python.org/3/library/logging.html |
+| controller.credentials.pass | string | `"adpass"` |  |
 | controller.credentials.user | string | `"admin"` |  |
-| controller.deployment.compconimage | string | `"tmforumodacanvas/component-istio-controller:0.2.6"` |  |
+| controller.deployment.compconImage | string | `"tmforumodacanvas/component-istio-controller:0.2.6"` |  |
+| controller.deployment.controllerName | string | `"oda-controller-ingress"` |  |
+| controller.deployment.dataDog.enabled | bool | `true` |  |
 | controller.deployment.ingressClass.enabled | bool | `false` |  |
 | controller.deployment.ingressClass.name | string | `"nginx"` |  |
 | controller.deployment.istioGateway | bool | `true` |  |
+| controller.deployment.keycloak.http | int | `8083` |  |
 | controller.deployment.monitoredNamespaces | string | `"components"` |  |
-| controller.deployment.controllerName | string | `"oda-controller-ingress"` |  |
 | controller.deployment.secconImage | string | `"tmforumodacanvas/security-listener:0.6.0"` |  |
-| global.certificate.appName | string | `"compcrdwebhook"` | Name of the certificate and webhook |
+| global.certificate.appName | string | `"compcrdwebhook"` | Name of the certificate and webhook | |
 | keycloak.auth.adminPassword | string | `"adpass"` |  |
 | keycloak.auth.adminUser | string | `"admin"` |  |
+| keycloak.containerPorts | object | `{"http":8083}` | Keycloak HTTP container port |
 | keycloak.enabled | bool | `true` |  |
 | keycloak.httpRelativePath | string | `"/auth/"` | Since keycloak 17+, default to / but the controllers work with older versions |
 | keycloak.ingress.enabled | bool | `false` |  |
 | keycloak.ingress.hosts[0].name | string | `"keycloak.local"` |  |
 | keycloak.ingress.hosts[0].path | string | `"/"` |  |
 | keycloak.ingress.hosts[0].tls | bool | `false` |  |
-| keycloak.ingress.ingressClassName | string | `"traefik"` | Legacy not used in when Istio |
-| keycloak.keycloakConfigCli.command[0] | string | `"java"` |  |
-| keycloak.keycloakConfigCli.command[1] | string | `"-jar"` |  |
-| keycloak.keycloakConfigCli.command[2] | string | `"/opt/keycloak-config-cli.jar"` |  |
-| keycloak.keycloakConfigCli.configuration."myrealm.json" | string | `"{\n  \"enabled\": true,\n  \"realm\": \"myrealm\",\n  \"users\": [\n    {\n    \"username\": \"seccon\",\n    \"email\": \"seccon@oda.io\",\n    \"enabled\": true,\n    \"firstName\": \"Security\",\n    \"lastName\": \"User\"\n    }\n   ]\n}\n"` | Create a myreal Realm with a seccon user|
-| keycloak.keycloakConfigCli.enabled | bool | `true` |  |
+| keycloak.ingress.ingressClassName | string | `"traefik"` |  |
+| keycloak.keycloakConfigCli | object | `{"backoffLimit":1,"command":["java","-jar","/opt/keycloak-config-cli.jar"],"configuration":{"myrealm.json":"{\n  \"enabled\": true,\n  \"realm\": \"myrealm\",\n  \"users\": [\n    {\n    \"username\": \"seccon\",\n    \"email\": \"seccon@oda.io\",\n    \"enabled\": true,\n    \"firstName\": \"Security\",\n    \"lastName\": \"User\"\n    }\n   ]\n}\n"},"enabled":true}` | Create a myrealm realm with a seccon user |
 | keycloak.postgresql.enabled | bool | `true` |  |
-| keycloak.postgresql.postgresqlDatabase | string | `"keycloak"` | For the Postgres used by Keycloak |
+| keycloak.postgresql.postgresqlDatabase | string | `"keycloak"` |  |
 | keycloak.postgresql.postgresqlPassword | string | `"keycloakdbuser"` |  |
 | keycloak.postgresql.postgresqlUsername | string | `"keycloak"` |  |
+| keycloak.service.ports.http | int | `8083` |  |
 | oda-cdrs.enabled | bool | `true` |  |
 | webhooks.image | string | `"tmforumodacanvas/compcrdwebhook:0.5.1"` |  |
 

--- a/canvas-simplified-install/canvas-oda/values.yaml
+++ b/canvas-simplified-install/canvas-oda/values.yaml
@@ -1,4 +1,4 @@
-# Recursive 
+# Recursive
 # https://github.com/helm/helm/issues/2247
 # https://github.com/Noksa/helm-resolve-deps
   # Default values for cert-manager-init.
@@ -6,6 +6,7 @@
   # Declare variables to be passed into your templates.
 global:
   certificate:
+    # -- Name of the certificate and webhook |
     appName: "compcrdwebhook"
 
 oda-cdrs:
@@ -15,6 +16,7 @@ canvas-namespaces:
   certManagerNamespace: cert-manager
   componentNamespace: components
   istio:
+    # --  Add Istion instrumentation label to the components namespace
     labelEnabledComponent: true
 cert-manager-init:
   nameOverride: ""
@@ -23,15 +25,17 @@ cert-manager-init:
   # The certificate has a default duration of 90d. It rotates automatically, but the the server using it doesn't handle that rotation
   # https://github.com/tmforum-oda/oda-canvas-charts/issues/38
   #
+  # -- Duration of the certificates generate for the webhook in hours |
   certificateDuration: 21600h
   #Cert manager get a lease  object on kube-system namespace to elect leader.
-  #The time to wait for a leader is 60s. 
+  #The time to wait for a leader is 60s.
   #The lease can survive among instalations, so cainjectot can waits up to 60s to become leader
   #If cainjector is not fully initilizaded we can find the following error
-  #  cert-manager-init/templates/issuer.yaml failed: Internal error occurred: 
-  #  failed calling webhook "webhook.cert-manager.io": failed to call webhook: 
+  #  cert-manager-init/templates/issuer.yaml failed: Internal error occurred:
+  #  failed calling webhook "webhook.cert-manager.io": failed to call webhook:
   #  Post "https://cert-manager-webhook.cert-manager.svc:443/mutate?timeout=10s": x509: certificate signed by unknown authority
   # In seconds
+  # -- Time to wait CertManager to be ready to prevent issuer creation errors
   leaseWaitTimeonStartup: 20
 
   cert-manager:
@@ -49,6 +53,7 @@ keycloak:
     postgresqlUsername: "keycloak"
     postgresqlPassword: "keycloakdbuser"
     postgresqlDatabase: "keycloak"
+  # -- Since keycloak 17+, default to / but the controllers work with older versions
   httpRelativePath: "/auth/"
   #proxy: edge
   #tls:
@@ -57,16 +62,15 @@ keycloak:
   #extraEnvVars:
   #  - name: PROXY_ADDRESS_FORWARDING
   #    value: "true"
-  ## @param containerPorts.http Keycloak HTTP container port
-  ## @param containerPorts.https Keycloak HTTPS container port
   ##
-  #containerPorts:
-  #  http: 8080
-  #  https: 8443
-  #service:
-  #  ports:
-  #    http: 8080
-  #Create a myrealm realm with a seccon user
+  # -- Keycloak LoadBalancer and Headless ClusterIp service port
+  service:
+    ports: &portKeycloak
+      http: 8083
+  # -- Keycloak HTTP container port
+  containerPorts: *portKeycloak
+
+  # -- Create a myrealm realm with a seccon user
   keycloakConfigCli:
     enabled: true
     backoffLimit: 1
@@ -99,18 +103,21 @@ controller:
     controllerName: oda-controller-ingress
     compconImage: tmforumodacanvas/component-istio-controller:0.2.6
     istioGateway: true
-    #gusjer/security-listener:0.7.0
     secconImage: tmforumodacanvas/security-listener:0.6.0
     monitoredNamespaces: 'components'           # comma separated list of namespaces
     ingressClass:
       enabled: false
       name: nginx
+    keycloak: *portKeycloak
+    dataDog:
+      enabled: true
   #We reuse the admin user created on keycloak instalation
   credentials:
     user: admin
     pass: adpass
   configmap:
     kcrealm: myrealm
+    # -- Log level [python] (https://docs.python.org/3/library/logging.html
     loglevel: '20'
 webhooks:
   image: tmforumodacanvas/compcrdwebhook:0.5.1

--- a/canvas-simplified-install/cert-manager-init/Chart.lock
+++ b/canvas-simplified-install/cert-manager-init/Chart.lock
@@ -3,4 +3,4 @@ dependencies:
   repository: https://charts.jetstack.io
   version: v1.11.0
 digest: sha256:fcc9298b47c0be880c1d125ec4014fdedd5a1f4df8c06165dfe47cf7d6e5a1ee
-generated: "2023-02-08T09:10:55.6699275+01:00"
+generated: "2023-03-03T11:51:34.7318675+01:00"

--- a/canvas-simplified-install/controller/Chart.yaml
+++ b/canvas-simplified-install/controller/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.0
+version: 1.0.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/canvas-simplified-install/controller/templates/configMap.yaml
+++ b/canvas-simplified-install/controller/templates/configMap.yaml
@@ -7,9 +7,12 @@ metadata:
   namespace: {{ .Release.Namespace }}
 data:
   LOGGING: {{ .Values.configmap.loglevel | quote }}
-  KEYCLOAK_BASE: "http://{{ .Release.Name }}-keycloak.{{ .Release.Namespace }}/auth"
+  KEYCLOAK_BASE: "http://{{ .Release.Name }}-keycloak-headless.{{ .Release.Namespace }}:{{ .Values.deployment.keycloak.http}}/auth"
   KEYCLOAK_REALM: {{ .Values.configmap.kcrealm }}
   COMPONENT_NAMESPACE: {{.Values.deployment.monitoredNamespaces}}
   {{- if .Values.deployment.ingressClass.enabled }}
   INGRESS_CLASS: {{ .Values.deployment.ingressClass.name }}
+  {{ end }}
+  {{- if .Values.deployment.dataDog.enabled }}
+  OPENMETRICS_IMPLEMENTATION: "DataDogAnnotation"
   {{ end }}

--- a/canvas-simplified-install/controller/values.yaml
+++ b/canvas-simplified-install/controller/values.yaml
@@ -7,6 +7,8 @@ deployment:
   ingressClass:
     enabled: false
     name: nginx
+  keycloak:
+    port: 8080
 #We reuse the admin user created on keycloak instalation
 credentials:
   user: admin
@@ -15,6 +17,6 @@ configmap:
   #kcbase: http://canvas-keycloak:8088/auth # trying to parameterise this in the configmap
   kcrealm: myrealm
   loglevel: '20'
- 
+
 
 


### PR DESCRIPTION
Add support to customize service port in Keycloak. default to 8083
Add support for dataDog environment variable 
close #56   
